### PR TITLE
Add boss battle transition after ninth verb

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 <link  rel="stylesheet" href="style.css">
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
-<body class="is-loading">
+<body id="game-container" class="is-loading">
   <div id="specific-modal-backdrop" class="specific-modal-backdrop" style="display:none;"></div>
   <div id="specific-info-modal" class="specific-modal" style="display:none;">
     <div class="specific-modal-content">
@@ -290,9 +290,10 @@
       </div>
 
       <div id="chuache-box">
-        <div id="chuache-container">
+        <div id="character-container">
           <div id="speech-bubble" class="speech-bubble hidden">You just got lucky.</div>
           <img id="chuache-image" src="images/conjuchuache.webp" alt="Chuache">
+          <img id="boss-image" src="images/boss_placeholder.png" alt="Boss" class="hidden">
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -452,6 +452,22 @@ document.addEventListener('DOMContentLoaded', async () => {
   const defaultBackgroundColor = getComputedStyle(document.documentElement)
     .getPropertyValue('--bg-color').trim();
 
+  // Elements for Boss Battle transitions
+  const gameContainer = document.getElementById('game-container');
+  const chuacheImage = document.getElementById('chuache-image');
+  const bossImage = document.getElementById('boss-image');
+  const progressContainer = document.getElementById('level-text');
+
+  const game = {
+    score: 0,
+    level: 1,
+    verbsInPhaseCount: 0,
+    gameState: 'PLAYING', // Possible states: PLAYING, BOSS_BATTLE
+    currentVerbs: [],
+    currentVerbIndex: 0,
+    isGameOver: false
+  };
+
 
   function resetBackgroundColor() {
     const gameMainPanel = document.getElementById('game-main-panel');
@@ -693,7 +709,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function updateProgressUI() {
-    const levelText = document.getElementById('level-text');
+    if (game.gameState !== 'PLAYING') return;
+    const levelText = progressContainer;
     if (!levelText) return;
 
     const goal = selectedGameMode === 'lives' ? LEVEL_GOAL_LIVES : LEVEL_GOAL_TIMER;
@@ -2783,6 +2800,28 @@ function prepareNextQuestion() {
   }
 }
 
+function startBossBattle() {
+  if (gameContainer) {
+    gameContainer.classList.add('boss-battle-bg');
+  }
+  if (progressContainer) {
+    progressContainer.textContent = 'LEVEL BOSS';
+    progressContainer.style.color = '#FF0000';
+  }
+  if (chuacheImage) {
+    chuacheImage.classList.add('fade-out');
+    setTimeout(() => {
+      chuacheImage.classList.add('hidden');
+      if (bossImage) bossImage.classList.remove('hidden');
+    }, 500);
+  }
+  if (qPrompt) qPrompt.textContent = '';
+  const tenseEl = document.getElementById('tense-label');
+  if (tenseEl) tenseEl.textContent = 'A new challenger appears...';
+  if (ansES) ansES.disabled = true;
+  if (ansEN) ansEN.disabled = true;
+}
+
 function checkAnswer() {
   // feedback.innerHTML is NO LONGER cleared here.
   const isStudyMode = (selectedGameMode === 'study');
@@ -3021,6 +3060,14 @@ else                   timeBonus = 10;
         showTimeChange(timeBonus);
 
     updateScore();
+
+    game.verbsInPhaseCount++;
+    if (game.verbsInPhaseCount === 9) {
+      game.gameState = 'BOSS_BATTLE';
+      startBossBattle();
+      return;
+    }
+
     setTimeout(prepareNextQuestion, 200);
 
     const irregularityEmojis = {

--- a/style.css
+++ b/style.css
@@ -3364,7 +3364,7 @@ body.is-loading .modal-backdrop:not(.specific-modal-backdrop) { /* :not para no 
 }
 
 .fade-out {
-    animation: fadeOutScreen 1s forwards;
+    animation: fadeOutScreen 0.5s forwards;
 }
 
 @keyframes fadeOutScreen {
@@ -3437,10 +3437,16 @@ td.irregular-highlight {
 }
 
 
-#chuache-image {
-  display: block;
+#chuache-image,
+#boss-image {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
+  height: 100%;
+  display: block;
   image-rendering: pixelated;
+  transition: opacity 0.5s ease-in-out;
 }
 
 @media (max-width: 600px) {
@@ -3460,10 +3466,18 @@ td.irregular-highlight {
    ========================================================================== */
 
 /* 1. The Character's Main Container (The Positioning Anchor) */
-#chuache-container {
+#character-container {
   position: relative; /* This is the anchor for the absolute-positioned bubble. */
+  width: 200px; /* Match your image width */
+  height: 200px; /* Match your image height */
+  margin: 20px auto;
   display: flex;
   justify-content: center;
+}
+
+.boss-battle-bg {
+  background-color: #000000;
+  transition: background-color 0.5s ease;
 }
 
 /* 2. The Speech Bubble's Main Body */


### PR DESCRIPTION
## Summary
- Trigger boss battle after ninth verb using dedicated game state and startBossBattle routine
- Style character container and boss battle background; fade Chuache out and show boss image
- Include hidden boss image tag without bundling placeholder asset

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68922e256994832798a3eebc101d525f