### PR TITLE
Add T-800 Disruptor boss and randomize boss battles

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,8 +301,10 @@
       <div id="bottom-panel">
         <div id="action-buttons">
           <button id="check-answer-button">Check Answer</button>
-          <button id="clue-button">Use Clue</button>
-          <button id="skip-button">Skip</button>
+          <div id="action-buttons-container">
+            <button id="clue-button" class="action-button">Pista</button>
+            <button id="skip-button" class="action-button">Saltar</button>
+          </div>
           <button id="end-button">END GAME</button>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -457,6 +457,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const chuacheImage = document.getElementById('chuache-image');
   const bossImage = document.getElementById('boss-image');
   const progressContainer = document.getElementById('level-text');
+  const clueButton = document.getElementById('clue-button');
+  const skipButton = document.getElementById('skip-button');
 
   const game = {
     score: 0,
@@ -480,6 +482,21 @@ document.addEventListener('DOMContentLoaded', async () => {
           id: 'skynetGlitch',
           verbsCompleted: 0,
           challengeVerbs: selectBossVerbs(this.verbsToComplete)
+        };
+        displayNextBossVerb();
+      }
+    },
+    t800Disruptor: {
+      name: 'T-800 Disruptor',
+      description: 'El Terminator ha desactivado tus botones.',
+      verbsToComplete: 3,
+      init: function () {
+        if (clueButton) clueButton.disabled = true;
+        if (skipButton) skipButton.disabled = true;
+        game.boss = {
+          id: 't800Disruptor',
+          verbsCompleted: 0,
+          challengeVerbs: game.currentVerbs.sort(() => 0.5 - Math.random()).slice(0, this.verbsToComplete)
         };
         displayNextBossVerb();
       }
@@ -541,7 +558,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const correctConjugation = verbData.conjugations[0];
 
-    if (qPrompt) qPrompt.textContent = glitchVerb(correctConjugation);
+    if (qPrompt) {
+      if (game.boss.id === 'skynetGlitch') {
+        qPrompt.textContent = glitchVerb(correctConjugation);
+      } else {
+        qPrompt.textContent = correctConjugation;
+      }
+    }
     const tenseEl = document.getElementById('tense-label');
     if (tenseEl) tenseEl.textContent = `(${verbData.tense})`;
     if (ansES) ansES.value = '';
@@ -553,9 +576,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     const tenseEl = document.getElementById('tense-label');
 
     if (playerWon) {
-      score += 500;
+      game.score += 500;
+      score = game.score;
+      const prizeText = game.boss.id === 't800Disruptor' ? "+500 Puntos y 3 Pistas" : "+500 Puntos!";
       if (qPrompt) qPrompt.textContent = 'SYSTEM RESTORED';
-      if (tenseEl) tenseEl.textContent = '+500 Points!';
+      if (tenseEl) tenseEl.textContent = prizeText;
+      if (game.boss.id === 't800Disruptor') {
+        freeClues += 3;
+      }
       updateScore();
     } else {
       if (qPrompt) qPrompt.textContent = 'SYSTEM FAILURE';
@@ -571,6 +599,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         progressContainer.style.color = '';
         updateLevelText(`Level ${game.level + 1} (0/9) | Total Score: ${score}`);
       }
+
+      if (clueButton) clueButton.disabled = false;
+      if (skipButton) skipButton.disabled = false;
 
       game.level++;
       game.verbsInPhaseCount = 0;
@@ -2931,7 +2962,9 @@ function startBossBattle() {
   }
 
   if (qPrompt) qPrompt.textContent = '';
-  const currentBoss = bosses.skynetGlitch; // Only boss for now
+  const bossKeys = Object.keys(bosses);
+  const randomBossKey = bossKeys[Math.floor(Math.random() * bossKeys.length)];
+  const currentBoss = bosses[randomBossKey];
   const tenseEl = document.getElementById('tense-label');
   if (tenseEl) tenseEl.textContent = currentBoss.description;
   if (ansES) {
@@ -3975,8 +4008,6 @@ if (irregularitiesContainer) {
     //prepareNextQuestion(); // Mantenla comentada por ahora hasta que todo el flujo funcione
     // <<<< INICIO DE LAS LÍNEAS MOVIDAS >>>>
     const checkAnswerButton = document.getElementById('check-answer-button');
-    const clueButton        = document.getElementById('clue-button');
-    const skipButton        = document.getElementById('skip-button');   // dentro de DOMContentLoaded si no son globales
     const endButton         = document.getElementById('end-button');
     const ansES             = document.getElementById('answer-input-es');
     const ansEN             = document.getElementById('answer-input-en');

--- a/style.css
+++ b/style.css
@@ -4126,3 +4126,28 @@ opacity: 0;
 transform: translateY(var(--fire-rise-height, -5em)) scale(0);
 }
 }
+
+#action-buttons-container {
+    margin-bottom: 15px;
+}
+
+.action-button {
+    background-color: #64FFDA;
+    color: #0A192F;
+    border: none;
+    padding: 8px 16px;
+    margin: 0 5px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 1em;
+    transition: background-color 0.3s, opacity 0.3s;
+}
+
+/* New style for disabled buttons */
+.action-button:disabled {
+    background-color: #3A4B68;
+    color: #8892B0;
+    opacity: 0.6;
+    cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- Introduce action button container with Clue and Skip controls so bosses can disable them
- Add T-800 Disruptor boss and random boss selection logic
- Style new action buttons and handle re-enabling after battles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689241b5ec6083278fa97fab8200941e