### PR TITLE
Fix Skynet Glitch boss verb selection and retry handling

### DIFF
--- a/style.css
+++ b/style.css
@@ -4126,3 +4126,14 @@ opacity: 0;
 transform: translateY(var(--fire-rise-height, -5em)) scale(0);
 }
 }
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  50% { transform: translateX(5px); }
+  75% { transform: translateX(-5px); }
+}
+
+.shake {
+  animation: shake 0.5s;
+}


### PR DESCRIPTION
## Summary
- Select boss verbs from filtered game list
- Simplify glitch effect to hide one random letter
- Allow retry after wrong boss answer and add shake animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924410ac8c8327a56cfa3310549fa0