### PR TITLE
Fix Skynet Glitch boss verb display

### DIFF
--- a/script.js
+++ b/script.js
@@ -521,11 +521,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     const verbIndex = game.boss.verbsCompleted;
     const verbData = game.boss.challengeVerbs[verbIndex];
 
-    const correctConjugation = verbData.conjugations[0];
+    const glitchedInfinitive = glitchVerb(verbData.infinitive);
 
-    if (qPrompt) qPrompt.textContent = glitchVerb(correctConjugation);
+    if (qPrompt) qPrompt.textContent = glitchedInfinitive;
     const tenseEl = document.getElementById('tense-label');
-    if (tenseEl) tenseEl.textContent = `(${verbData.tense})`;
+    if (tenseEl) tenseEl.textContent = `${verbData.tense} - ${verbData.pronoun}`;
     if (ansES) ansES.value = '';
   }
 


### PR DESCRIPTION
## Summary
- Display glitched infinitive and conjugation context during Skynet Glitch boss battles

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689370bed64483279d0b61c84133f77a