### PR TITLE
Include correct answer in Skynet Glitch challenges

### DIFF
--- a/script.js
+++ b/script.js
@@ -511,6 +511,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             infinitive: verb.infinitive_es,
             tense,
             pronoun,
+            correctAnswer,
             conjugations: [correctAnswer],
             glitchedForm
           });


### PR DESCRIPTION
## Summary
- Add `correctAnswer` property to `challengeVerbs` when initializing Skynet Glitch challenges to track expected conjugations.

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68938323429883279d4fca761cfde98a