### PR TITLE
Guard clue and question setup during boss battle

### DIFF
--- a/script.js
+++ b/script.js
@@ -758,6 +758,7 @@ function displayNextBossVerb() {
   }
 
   function onClueButtonClick() {
+    if (game.gameState === 'BOSS_BATTLE') return;
     feedback.innerHTML = '';
     if (selectedGameMode !== 'timer' && selectedGameMode !== 'lives') {
       timerTimeLeft = Math.max(0, timerTimeLeft - 3);
@@ -2779,6 +2780,7 @@ let usedVerbs = [];
 
 	navigateToStep('splash'); // Empezar en el splash screen  
 function prepareNextQuestion() {
+  if (game.gameState === 'BOSS_BATTLE') return;
   const feedback = document.getElementById('feedback-message');
   // feedback.innerHTML = '';
   feedback.classList.remove('vibrate');


### PR DESCRIPTION
## Summary
- Prevent players from requesting clues during boss battles
- Skip preparing new questions while in boss battle state

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68938327fe808327b7d3c555c2c83297