### PR TITLE
Re-enable inputs after boss battle

### DIFF
--- a/script.js
+++ b/script.js
@@ -573,7 +573,7 @@ function displayNextBossVerb() {
 }
 
   function endBossBattle(playerWon, message = "") {
-    if (ansES) ansES.disabled = true;
+    if (ansES) ansES.disabled = false;
 
     const tenseEl = document.getElementById('tense-label');
 
@@ -604,6 +604,9 @@ function displayNextBossVerb() {
       game.gameState = 'PLAYING';
       game.boss = null;
 
+      if (checkAnswerButton) checkAnswerButton.disabled = false;
+      if (clueButton) clueButton.disabled = false;
+      if (skipButton) skipButton.disabled = false;
       prepareNextQuestion();
     }, 3000);
   }


### PR DESCRIPTION
## Summary
- Re-enable answer input at the start of boss battle cleanup so players can type again.
- Restore Check Answer, Clue, and Skip buttons after boss fights and prepare the next question.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893832b3e7083279d1bc17320f8bba0