### PR TITLE
Track last boss used for selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -466,7 +466,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     currentVerbs: [],
     currentVerbIndex: 0,
     isGameOver: false,
-    boss: null // Will hold the current boss battle state
+    boss: null, // Will hold the current boss battle state
+    lastBossUsed: null // Track the previously selected boss
   };
 
   // Bosses definition
@@ -525,12 +526,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // Step 5: Set up the boss state
         game.boss = {
-          id: 'skynetGlitch',
+          id: game.lastBossUsed,
           verbsCompleted: 0,
-          challengeVerbs
+          challengeVerbs,
+          totalVerbsNeeded: this.verbsToComplete
         };
 
-        console.log('Skynet Glitch challenge verbs:', game.boss.challengeVerbs);
+        console.log(`${this.name} challenge verbs:`, game.boss.challengeVerbs);
 
         // Step 6: Display the first glitched verb
         displayNextBossVerb();
@@ -2951,17 +2953,21 @@ function startBossBattle() {
   document.body.classList.add('boss-battle-bg');
   if (gameContainer) gameContainer.classList.add('boss-battle-bg');
 
-  const currentBoss = bosses.skynetGlitch; // Only boss for now
-  if (bossImage) bossImage.src = 'images/bosssg.webp';
-  game.boss = {
-    id: 'skynetGlitch',
-    verbsCompleted: 0,
-    challengeVerbs: [],
-    totalVerbsNeeded: currentBoss.verbsToComplete
-  };
+  const bossKeys = Object.keys(bosses);
+  let bossKey = bossKeys[Math.floor(Math.random() * bossKeys.length)];
+  if (bossKeys.length > 1 && bossKey === game.lastBossUsed) {
+    const remaining = bossKeys.filter(k => k !== game.lastBossUsed);
+    bossKey = remaining[Math.floor(Math.random() * remaining.length)];
+  }
+  game.lastBossUsed = bossKey;
+  const currentBoss = bosses[bossKey];
+
+  if (bossImage) {
+    if (bossKey === 'skynetGlitch') bossImage.src = 'images/bosssg.webp';
+  }
 
   if (progressContainer) {
-    progressContainer.textContent = 'BOSS BATTLE - SKYNET GLITCH';
+    progressContainer.textContent = `BOSS BATTLE - ${currentBoss.name.toUpperCase()}`;
     progressContainer.style.color = '#FF0000';
   }
 


### PR DESCRIPTION
## Summary
- track the last boss in game state via `lastBossUsed`
- select bosses using `game.lastBossUsed` to avoid repeats
- initialize boss state with the recorded last boss and verb requirements

## Testing
- `node --check script.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893890c47b48327b65046e2f4740703