### PR TITLE
Add verbRepairer and updated Skynet Glitch bosses

### DIFF
--- a/script.js
+++ b/script.js
@@ -471,9 +471,74 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Bosses definition
   const bosses = {
+    verbRepairer: {
+      name: 'Digital Corrupted',
+      description: 'Una interferencia digital ha dañado los verbos.',
+      verbsToComplete: 3,
+      init: function() {
+        // Step 1: Filter all verbs to those with long infinitives and at least one regular tense.
+        const filteredVerbs = allVerbData.filter(v => {
+          if (!v.infinitive_es || v.infinitive_es.length <= 5) return false;
+          return currentOptions.tenses.some(t => Array.isArray(v.types?.[t]) && v.types[t].includes('regular'));
+        });
+
+        // Step 2: Randomly select the verbs for this battle.
+        const shuffled = filteredVerbs.sort(() => Math.random() - 0.5);
+        const selected = shuffled.slice(0, this.verbsToComplete);
+
+        // Step 3: Handle the case where not enough verbs are available.
+        if (selected.length < this.verbsToComplete) {
+          console.error('Not enough compatible verbs to start Digital Corrupted boss.');
+          endBossBattle(false, 'ERROR: No hay verbos compatibles.');
+          return;
+        }
+
+        // Step 4: Build the challenge verbs with random tense and pronoun.
+        const pronounList = window.pronouns || pronouns;
+        const challengeVerbs = [];
+
+        selected.forEach(verb => {
+          const possibleTenses = currentOptions.tenses.filter(t => Array.isArray(verb.types?.[t]) && verb.types[t].includes('regular'));
+          const tense = possibleTenses[Math.floor(Math.random() * possibleTenses.length)];
+          const pronoun = pronounList[Math.floor(Math.random() * pronounList.length)];
+          const correctAnswer = verb.conjugations?.[tense]?.[pronoun];
+          if (!correctAnswer) {
+            console.error(`Missing conjugation for ${verb.infinitive_es} in ${tense} (${pronoun}).`);
+            return;
+          }
+          const glitchedForm = glitchVerb(correctAnswer);
+          challengeVerbs.push({
+            infinitive: verb.infinitive_es,
+            tense,
+            pronoun,
+            correctAnswer,
+            conjugations: [correctAnswer],
+            glitchedForm
+          });
+        });
+
+        if (challengeVerbs.length < this.verbsToComplete) {
+          console.error('Not enough challenge verbs after processing for Digital Corrupted.');
+          endBossBattle(false, 'ERROR: No hay verbos compatibles.');
+          return;
+        }
+
+        // Step 5: Set up the boss state
+        game.boss = {
+          id: 'verbRepairer',
+          verbsCompleted: 0,
+          challengeVerbs
+        };
+
+        console.log('Digital Corrupted challenge verbs:', game.boss.challengeVerbs);
+
+        // Step 6: Display the first glitched verb
+        displayNextBossVerb();
+      }
+    },
     skynetGlitch: {
       name: 'Skynet Glitch',
-      description: 'Una interferencia digital ha dañado los verbos.',
+      description: 'Skynet demands accurate conjugations.',
       verbsToComplete: 3,
       init: function() {
         // Step 1: Filter all verbs to those with long infinitives and at least one regular tense.
@@ -506,14 +571,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             console.error(`Missing conjugation for ${verb.infinitive_es} in ${tense} (${pronoun}).`);
             return;
           }
-          const glitchedForm = glitchVerb(correctAnswer);
           challengeVerbs.push({
             infinitive: verb.infinitive_es,
             tense,
             pronoun,
             correctAnswer,
-            conjugations: [correctAnswer],
-            glitchedForm
+            conjugations: [correctAnswer]
           });
         });
 
@@ -532,7 +595,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         console.log('Skynet Glitch challenge verbs:', game.boss.challengeVerbs);
 
-        // Step 6: Display the first glitched verb
+        // Step 6: Display the first verb
         displayNextBossVerb();
       }
     }
@@ -563,10 +626,23 @@ function displayNextBossVerb() {
       console.error("No current boss challenge found.");
       return;
     }
-    if (qPrompt)
-      qPrompt.innerHTML = `<span class="boss-challenge">${currentChallenge.glitchedForm}</span>`;
+    if (qPrompt) {
+      let displayText;
+      if (game.boss.id === 'verbRepairer') {
+        displayText = currentChallenge.glitchedForm;
+      } else {
+        displayText = `${currentChallenge.infinitive} - ${currentChallenge.pronoun}`;
+      }
+      qPrompt.innerHTML = `<span class="boss-challenge">${displayText}</span>`;
+    }
     const tenseEl = document.getElementById('tense-label');
-    if (tenseEl) tenseEl.textContent = `Repair the verb (${currentChallenge.tense})`;
+    if (tenseEl) {
+      if (game.boss.id === 'verbRepairer') {
+        tenseEl.textContent = `Repair the verb (${currentChallenge.tense})`;
+      } else {
+        tenseEl.textContent = `Conjugate (${currentChallenge.tense})`;
+      }
+    }
     if (ansES) {
       ansES.value = '';
       ansES.focus();
@@ -2951,17 +3027,18 @@ function startBossBattle() {
   document.body.classList.add('boss-battle-bg');
   if (gameContainer) gameContainer.classList.add('boss-battle-bg');
 
-  const currentBoss = bosses.skynetGlitch; // Only boss for now
+  const currentBossKey = 'verbRepairer'; // Only boss for now
+  const currentBoss = bosses[currentBossKey];
   if (bossImage) bossImage.src = 'images/bosssg.webp';
   game.boss = {
-    id: 'skynetGlitch',
+    id: currentBossKey,
     verbsCompleted: 0,
     challengeVerbs: [],
     totalVerbsNeeded: currentBoss.verbsToComplete
   };
 
   if (progressContainer) {
-    progressContainer.textContent = 'BOSS BATTLE - SKYNET GLITCH';
+    progressContainer.textContent = `BOSS BATTLE - ${currentBoss.name.toUpperCase()}`;
     progressContainer.style.color = '#FF0000';
   }
 
@@ -3007,13 +3084,17 @@ function checkAnswer() {
     const userInput = ansES.value.trim().toLowerCase();
     const correctAnswer = currentChallenge.correctAnswer.trim().toLowerCase();
 
+    const challengeDisplay = game.boss.id === 'verbRepairer'
+      ? currentChallenge.glitchedForm
+      : `${currentChallenge.infinitive} - ${currentChallenge.pronoun} (${currentChallenge.tense})`;
+
     if (userInput === correctAnswer) {
       game.boss.verbsCompleted++;
       game.score += 50;
       score = game.score; // keep legacy score in sync
       updateScore();
       if (feedback)
-        feedback.textContent = `✅ Correct! "${currentChallenge.glitchedForm}" → "${currentChallenge.correctAnswer}" (+50 points)`;
+        feedback.textContent = `✅ Correct! "${challengeDisplay}" → "${currentChallenge.correctAnswer}" (+50 points)`;
 
       if (game.boss.verbsCompleted >= bosses[game.boss.id].verbsToComplete) {
         endBossBattle(true);
@@ -3024,8 +3105,12 @@ function checkAnswer() {
       game.score = Math.max(0, game.score - 20);
       score = game.score; // keep legacy score in sync
       updateScore();
-      if (feedback)
-        feedback.textContent = `❌ Incorrect. Try to repair: "${currentChallenge.glitchedForm}"`;
+      if (feedback) {
+        const msg = game.boss.id === 'verbRepairer'
+          ? `❌ Incorrect. Try to repair: "${challengeDisplay}"`
+          : `❌ Incorrect. "${challengeDisplay}"`;
+        feedback.textContent = msg;
+      }
 
       if (gameContainer) {
         gameContainer.classList.add('shake');


### PR DESCRIPTION
## Summary
- rename original Skynet Glitch boss to `verbRepairer` with name "Digital Corrupted" while keeping its glitch-based setup
- add a new `skynetGlitch` boss that uses the same selection logic but displays full infinitive, pronoun, and tense
- adjust boss battle logic to handle both bosses

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893890e2d2c8327a8a13543b32aa63e