### PR TITLE
Handle different boss displays

### DIFF
--- a/script.js
+++ b/script.js
@@ -563,10 +563,22 @@ function displayNextBossVerb() {
       console.error("No current boss challenge found.");
       return;
     }
-    if (qPrompt)
-      qPrompt.innerHTML = `<span class="boss-challenge">${currentChallenge.glitchedForm}</span>`;
+    if (qPrompt) {
+      if (game.boss.id === 'skynetGlitch') {
+        qPrompt.innerHTML = `<span class="boss-challenge">${currentChallenge.infinitive} (${currentChallenge.pronoun})</span>`;
+      } else {
+        // Default to verbRepairer behavior
+        qPrompt.innerHTML = `<span class="boss-challenge">${currentChallenge.glitchedForm}</span>`;
+      }
+    }
     const tenseEl = document.getElementById('tense-label');
-    if (tenseEl) tenseEl.textContent = `Repair the verb (${currentChallenge.tense})`;
+    if (tenseEl) {
+      if (game.boss.id === 'skynetGlitch') {
+        tenseEl.textContent = `Conjugate in ${currentChallenge.tense}`;
+      } else {
+        tenseEl.textContent = `Repair the verb (${currentChallenge.tense})`;
+      }
+    }
     if (ansES) {
       ansES.value = '';
       ansES.focus();


### PR DESCRIPTION
## Summary
- Branch `displayNextBossVerb` on boss id to support multiple boss styles
- Show infinitive and pronoun with "Conjugate in" tense label for skynetGlitch
- Maintain glitched display for verbRepairer and clear/focus answer input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68938910475c8327a2874387a6dea424