### PR TITLE
Trigger audio cues in boss battle answers

### DIFF
--- a/script.js
+++ b/script.js
@@ -3169,6 +3169,8 @@ function checkAnswer() {
       if (feedback)
         feedback.textContent = `✅ Correct! "${challengeDisplay}" → "${currentChallenge.correctAnswer}" (+50 points)`;
 
+      safePlay(soundCorrect);
+
       if (game.boss.verbsCompleted >= bosses[game.boss.id].verbsToComplete) {
         endBossBattle(true);
       } else {
@@ -3184,6 +3186,8 @@ function checkAnswer() {
           : `❌ Incorrect. "${challengeDisplay}"`;
         feedback.textContent = msg;
       }
+
+      safePlay(soundWrong);
 
       if (gameContainer) {
         gameContainer.classList.add('shake');


### PR DESCRIPTION
## Summary
- Play correct-answer sound during boss battles
- Play wrong-answer sound during boss battles
- Omit Chuache voice reactions when the character is absent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894a39754b483278fce8815da5abf43