### PR TITLE
Fix boss battle level progress handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -762,10 +762,11 @@ function displayNextBossVerb() {
       if (chuacheImage) chuacheImage.classList.remove('hidden', 'fade-out');
       if (progressContainer) {
         progressContainer.style.color = '';
-        updateLevelText(`Level ${game.level + 1} (0/9) | Total Score: ${score}`);
+        const goal = selectedGameMode === 'lives' ? LEVEL_GOAL_LIVES : LEVEL_GOAL_TIMER;
+        const progress = correctAnswersTotal % goal;
+        updateLevelText(`Level ${currentLevel + 1} (${progress}/${goal}) | Total Score: ${score}`);
       }
 
-      game.level++;
       game.verbsInPhaseCount = 0;
       game.gameState = 'PLAYING';
       game.boss = null;


### PR DESCRIPTION
## Summary
- keep boss battle progress from resetting `correctAnswersTotal`/`currentLevel`
- compute game mode goal and update level text without advancing level

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ac201efc8327958b9900ebe6ea14