### PR TITLE
Display boss defeat feedback and labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -746,9 +746,9 @@ function displayNextBossVerb() {
     if (playerWon) {
       game.score += 500;
       score = game.score; // keep legacy score in sync
-      const prizeText = "+500 Puntos!";
       if (qPrompt) qPrompt.textContent = 'SYSTEM RESTORED';
-      if (tenseEl) tenseEl.textContent = prizeText;
+      if (tenseEl) tenseEl.textContent = 'Boss defeated!';
+      if (feedback) feedback.innerHTML = '<span class="feedback-points">Boss Bonus: +500 Points!</span>';
       updateScore();
     } else {
       if (qPrompt) qPrompt.textContent = message || 'SYSTEM FAILURE';


### PR DESCRIPTION
## Summary
- Update boss battle win logic to show "SYSTEM RESTORED" and "Boss defeated!"
- Show boss bonus points in feedback message and keep score updated

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6894ac214a688327bbb03456fa3a2ba3