### PR TITLE
Use bosshack image for Verb Repairer boss

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
         <div id="character-container">
           <div id="speech-bubble" class="speech-bubble hidden">You just got lucky.</div>
           <img id="chuache-image" src="images/conjuchuache.webp" alt="Chuache">
-          <img id="boss-image" src="images/bossrepairer.webp" alt="Skynet Glitch Boss" class="hidden">
+          <img id="boss-image" src="images/bosssg.webp" alt="Skynet Glitch Boss" class="hidden">
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -3165,7 +3165,7 @@ function startBossBattle() {
 
   if (bossImage) {
     bossImage.src = selectedBossKey === 'verbRepairer'
-      ? 'images/bossrepairer.webp'
+      ? 'images/bosshack.webp'
       : 'images/bosssg.webp';
   }
 


### PR DESCRIPTION
## Summary
- Default boss image set to `bosssg.webp`
- Display `bosshack.webp` when facing the Verb Repairer

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6894ac7dab0483279684b1b89ff1bb15