### PR TITLE
Refactor Skynet Glitch boss challenge

### DIFF
--- a/script.js
+++ b/script.js
@@ -598,6 +598,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       description: 'Skynet demands accurate conjugations.',
       verbsToComplete: 3,
       init: function() {
+        // Gather verbs based on current filters
         const selectedVerbEls = Array.from(
           document.querySelectorAll('#verb-buttons .verb-button.selected')
         );
@@ -620,26 +621,36 @@ document.addEventListener('DOMContentLoaded', async () => {
           );
         }
 
-        verbPool = verbPool.filter(v => v.infinitive_es && v.infinitive_es.length >= 6);
-
         if (verbPool.length < this.verbsToComplete) {
           console.error('Not enough compatible verbs for Skynet Glitch.');
           endBossBattle(false, 'ERROR: No hay verbos compatibles.');
           return;
         }
 
-        const selected = verbPool.sort(() => Math.random() - 0.5).slice(0, this.verbsToComplete);
         const pronounList = window.pronouns || pronouns;
-        const challengeVerbs = selected.map(verb => {
-          const tense = currentOptions.tenses[Math.floor(Math.random() * currentOptions.tenses.length)];
-          const pronoun = pronounList[Math.floor(Math.random() * pronounList.length)];
-          return {
-            glitchedInfinitive: glitchInfinitive(verb.infinitive_es),
-            pronoun,
-            tense,
-            correctAnswer: verb.infinitive_es
-          };
-        });
+        const shuffled = verbPool.sort(() => Math.random() - 0.5).slice(0, this.verbsToComplete);
+        const challengeVerbs = shuffled
+          .map(verb => {
+            const tense = currentOptions.tenses[Math.floor(Math.random() * currentOptions.tenses.length)];
+            const pronoun = pronounList[Math.floor(Math.random() * pronounList.length)];
+            const correctAnswer = verb.conjugations?.[tense]?.[pronoun];
+            if (!correctAnswer) return null;
+            const glitchedConjugation = glitchVerb(correctAnswer);
+            return {
+              infinitive: verb.infinitive_es,
+              tense,
+              pronoun,
+              correctAnswer,
+              glitchedConjugation
+            };
+          })
+          .filter(Boolean);
+
+        if (challengeVerbs.length < this.verbsToComplete) {
+          console.error('Not enough challenge verbs after processing for Skynet Glitch.');
+          endBossBattle(false, 'ERROR: No hay verbos compatibles.');
+          return;
+        }
 
         game.boss = {
           id: 'skynetGlitch',
@@ -923,10 +934,18 @@ function displayNextBossVerb() {
         `<span class="tense-badge ${tKey}" data-info-key="${infoKey}">${tenseLabel}` +
         `<span class="context-info-icon" data-info-key="${infoKey}"></span></span>`;
       promptHTML = `${tenseBadge} <span class="boss-challenge">${currentChallenge.glitchedForm}</span>`;
-    } else if (game.boss.id === 'skynetGlitch') {
-      if (tenseEl) tenseEl.textContent = 'Complete the infinitive';
-      promptHTML = `<span class="boss-challenge">${currentChallenge.pronoun} - ${currentChallenge.glitchedInfinitive}</span>`;
-    } else if (game.boss.id === 'nuclearBomb') {
+      } else if (game.boss.id === 'skynetGlitch') {
+        if (tenseEl) tenseEl.textContent = 'Repair the conjugation';
+        const tKey = currentChallenge.tense;
+        const tenseObj = tenses.find(t => t.value === tKey) || {};
+        const tenseLabel = tenseObj.name || tKey;
+        const infoKey = tenseObj.infoKey || '';
+        const tenseBadge =
+          `<span class="tense-badge ${tKey}" data-info-key="${infoKey}">${tenseLabel}` +
+          `<span class="context-info-icon" data-info-key="${infoKey}"></span></span>`;
+        promptHTML =
+          `${tenseBadge}: "${currentChallenge.infinitive}" – <span class="pronoun" id="${currentChallenge.pronoun}">${currentChallenge.pronoun}</span> – <span class="boss-challenge">${currentChallenge.glitchedConjugation}</span>`;
+      } else if (game.boss.id === 'nuclearBomb') {
       if (tenseEl) tenseEl.textContent = `Defuse the bomb! (${game.boss.verbsCompleted + 1}/${game.boss.totalVerbsNeeded})`;
 
       const tKey = currentChallenge.tense;


### PR DESCRIPTION
## Summary
- Rebuild Skynet Glitch boss to pull verbs from current filters, select random tense/pronoun, and glitch the resulting conjugation.
- Initialize game boss state with new challenge verbs and trigger display of the first boss verb.
- Show tense badge, pronoun, and glitched conjugation in the boss prompt.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c25b9c648327a3ebff36ba695f70