### PR TITLE
Add global boss encounter counters

### DIFF
--- a/script.js
+++ b/script.js
@@ -86,6 +86,8 @@ function safePlay(audio) {
 }
 
 // Level progression state
+let totalBossesEncountered = 0;
+let currentBossNumber = 0;
 let correctAnswersTotal = 0;
 let currentLevel = 0;
 let lastBossUsed = null;


### PR DESCRIPTION
## Summary
- Add `totalBossesEncountered` and `currentBossNumber` globals in `script.js`
- Prepare for tracking boss battles across `startBossBattle`, `checkAnswer`, and `endBossBattle`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c25e47888327ba76862ed79c07e1