### PR TITLE
Restore level display after boss battles

### DIFF
--- a/script.js
+++ b/script.js
@@ -998,14 +998,13 @@ function displayNextBossVerb() {
       if (chuacheImage) chuacheImage.classList.remove('hidden', 'fade-out');
       if (progressContainer) {
         progressContainer.style.color = '';
-        const goal = selectedGameMode === 'lives' ? LEVEL_GOAL_LIVES : LEVEL_GOAL_TIMER;
-        const progress = correctAnswersTotal % goal;
-        updateLevelText(`Level ${currentLevel + 1} (${progress}/${goal}) | Total Score: ${score}`);
       }
 
       game.verbsInPhaseCount = 0;
       game.gameState = 'PLAYING';
       game.boss = null;
+
+      if (progressContainer) updateProgressUI();
 
       prepareNextQuestion();
     }, 3000);


### PR DESCRIPTION
## Summary
- Reset progress text using standard `updateProgressUI` after a boss fight
- Ensure boss completion leaves `currentLevel` untouched so defeating a boss doesn't level up the player

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c2623d688327b6dc3534e422b62d