### PR TITLE
Reset boss counters when starting a game

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,6 +89,8 @@ function safePlay(audio) {
 let correctAnswersTotal = 0;
 let currentLevel = 0;
 let lastBossUsed = null;
+let totalBossesEncountered = 0;
+let currentBossNumber = 0;
 
 // Temporary level goals for testing
 const LEVEL_GOAL_TIMER = 10;
@@ -4042,6 +4044,8 @@ if (reflexiveBonus > 0) {
   }
 }
 function startTimerMode() {
+  totalBossesEncountered = 0;
+  currentBossNumber = 0;
   document.getElementById('timer-container').style.display = 'flex';
   freeClues = 3;
   updateClueButtonUI();
@@ -4143,6 +4147,8 @@ function startTimerMode() {
 }
 
 function startLivesMode() {
+  totalBossesEncountered = 0;
+  currentBossNumber = 0;
   freeClues = 3;
   updateClueButtonUI();
   resetLevelState();
@@ -4501,6 +4507,8 @@ finalStartGameButton.addEventListener('click', async () => {
     } else if (window.selectedGameMode === 'lives') {
         startLivesMode();
     } else {
+        totalBossesEncountered = 0;
+        currentBossNumber = 0;
         freeClues = 0;
         updateClueButtonUI();
         safePlay(soundStart);


### PR DESCRIPTION
## Summary
- Track boss encounter stats with new totalBossesEncountered and currentBossNumber globals
- Reset boss counters when starting timer or lives modes
- Ensure study mode also resets boss counters before play

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894c263fa4883278b5232e1d8ed6673