### PR TITLE
Show final boss progress when nuclear bomb is defused

### DIFF
--- a/script.js
+++ b/script.js
@@ -873,6 +873,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (countdownDisplay) {
       countdownDisplay.classList.add('defused');
     }
+    if (progressContainer) {
+      progressContainer.textContent = `Level Boss #${currentBossNumber} - 3/3 (${game.boss.totalVerbsNeeded}/${game.boss.totalVerbsNeeded}) | Total Score: ${score}`;
+    }
 
     endNuclearBoss(true, 'BOMB DEFUSED!');
   }


### PR DESCRIPTION
## Summary
- Update defuseNuclearBomb to display final boss progress and total score before ending the battle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c26b21d48327a0950fc437435b6d