### PR TITLE
Track response times and missed verbs

### DIFF
--- a/script.js
+++ b/script.js
@@ -3858,6 +3858,10 @@ correct = possibleCorrectAnswers.includes(ans);
     feedback.innerHTML = ''; // Clear feedback area ONLY on correct answer.
     // *** MODIFICATION END ***
 
+    const responseTime = (Date.now() - questionStartTime) / 1000;
+    totalResponseTime += responseTime;
+    if (responseTime < fastestAnswer) fastestAnswer = responseTime;
+
     // Manejo del sonido
     if (soundCorrect) {
       soundCorrect.pause();
@@ -4034,6 +4038,13 @@ if (reflexiveBonus > 0) {
     return;   
   } else {
     // --- INCORRECT ANSWER ---
+    totalIncorrect++;
+    verbsMissed.push({
+      verb: currentQuestion.verb.infinitive_es,
+      english: currentQuestion.verb.infinitive_en,
+      tense: currentQuestion.tenseKey
+    });
+
     if (isStudyMode) {
       safePlay(soundWrongStudy);
     } else {


### PR DESCRIPTION
## Summary
- Measure player response time on correct answers and update fastest/average metrics.
- Record incorrect attempts, tallying misses with verb and tense details.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa87f571c0832791c317bcb4ed3d17