### PR TITLE
Add statistics grid styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -4319,3 +4319,9 @@ transform: translateY(var(--fire-rise-height, -5em)) scale(0);
 #chuache-box.nuclear-mode #speech-bubble {
   display: none;
 }
+
+.stats-grid { display: flex; flex-direction: column; gap: 15px; }
+.stat-row { display: flex; justify-content: space-between; align-items: center; padding: 10px; background-color: rgba(255,255,255,0.1); border-radius: 5px; }
+.stat-label { font-weight: bold; color: var(--accent-color-blue); }
+.stat-value { color: var(--title-color); font-size: 1.1em; }
+.encouragement { text-align: center; font-size: 1.3em; color: var(--feedback-correct); margin-top: 15px; font-weight: bold; }


### PR DESCRIPTION
## Summary
- style stats grid and rows for stats display
- add styling for labels, values, and encouragement message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8a2c1a2883278a259745941e264a