### PR TITLE
Reset gameplay stats on new game

### DIFF
--- a/script.js
+++ b/script.js
@@ -4174,6 +4174,13 @@ if (reflexiveBonus > 0) {
   }
 }
 function startTimerMode() {
+  totalQuestions = 0;
+  totalCorrect = 0;
+  totalIncorrect = 0;
+  totalResponseTime = 0;
+  verbsMissed = [];
+  fastestAnswer = Infinity;
+  bestStreak = 0;
   totalBossesEncountered = 0;
   currentBossNumber = 0;
   document.getElementById('timer-container').style.display = 'flex';
@@ -4277,6 +4284,13 @@ function startTimerMode() {
 }
 
 function startLivesMode() {
+  totalQuestions = 0;
+  totalCorrect = 0;
+  totalIncorrect = 0;
+  totalResponseTime = 0;
+  verbsMissed = [];
+  fastestAnswer = Infinity;
+  bestStreak = 0;
   totalBossesEncountered = 0;
   currentBossNumber = 0;
   freeClues = 3;


### PR DESCRIPTION
## Summary
- Reset counters and streak variables at the start of Timer and Lives modes to ensure fresh state each run

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8cd96bcc83278043509c46f0f6ed