### PR TITLE
feat: add boss tooltips and T-1000 hint system

### DIFF
--- a/script.js
+++ b/script.js
@@ -983,8 +983,6 @@ function displayNextT1000Verb() {
     return;
   }
 
-  totalQuestions++;
-  
   const currentChallenge = game.boss.challengeVerbs[game.boss.verbsCompleted];
   if (!currentChallenge) {
     console.error("No current T-1000 challenge found.");
@@ -993,9 +991,25 @@ function displayNextT1000Verb() {
 
   const tenseEl = document.getElementById('tense-label');
   if (tenseEl) {
-    tenseEl.textContent = `T-1000 Mirror (${game.boss.verbsCompleted + 1}/${game.boss.totalVerbsNeeded})`;
+    // Add tooltip to boss title
+    tenseEl.innerHTML = `<span class="boss-title-with-tooltip" data-info-key="t1000BossInfo">T-1000 Mirror (${game.boss.verbsCompleted + 1}/${game.boss.totalVerbsNeeded}) <span class="context-info-icon" data-info-key="t1000BossInfo"></span></span>`;
+    const tooltipIcon = tenseEl.querySelector('.context-info-icon');
+    const titleWithTooltip = tenseEl.querySelector('.boss-title-with-tooltip');
+    if (tooltipIcon) {
+      tooltipIcon.addEventListener('click', e => {
+        e.stopPropagation();
+        if (typeof soundClick !== 'undefined') safePlay(soundClick);
+        openSpecificModal('t1000BossInfo');
+      });
+    }
+    if (titleWithTooltip) {
+      titleWithTooltip.addEventListener('click', () => {
+        if (typeof soundClick !== 'undefined') safePlay(soundClick);
+        openSpecificModal('t1000BossInfo');
+      });
+    }
   }
-  
+
   let promptHTML = '';
   const tKey = currentChallenge.tense;
   const tenseObj = tenses.find(t => t.value === tKey) || {};
@@ -1003,18 +1017,17 @@ function displayNextT1000Verb() {
   const infoKey = tenseObj.infoKey || '';
   const tenseBadge = `<span class="tense-badge ${tKey}" data-info-key="${infoKey}">${tenseLabel}<span class="context-info-icon" data-info-key="${infoKey}"></span></span>`;
 
+  // NEW: Do not show the reversed answer
   if (currentOptions.mode === 'receptive') {
-    promptHTML = `🪞 MIRROR: ${tenseBadge} "${currentChallenge.correctAnswer}" → <span class="t1000-hint">(Reverse the English translation)</span>`;
+    promptHTML = `🪞 MIRROR: ${tenseBadge} "${currentChallenge.correctAnswer}" → <span class="t1000-hint">(Type the English translation backwards)</span>`;
   } else if (currentOptions.mode === 'productive_easy') {
-    promptHTML = `🪞 MIRROR: ${tenseBadge} "${currentChallenge.infinitive}" – <span class="pronoun" id="${currentChallenge.pronoun}">${currentChallenge.pronoun}</span> → <span class="t1000-hint">(${currentChallenge.correctAnswer} → ${currentChallenge.reversedAnswer})</span>`;
+    promptHTML = `🪞 MIRROR: ${tenseBadge} "${currentChallenge.infinitive}" – <span class="pronoun" id="${currentChallenge.pronoun}">${currentChallenge.pronoun}</span>`;
   } else {
-    promptHTML = `🪞 MIRROR: ${tenseBadge} "${currentChallenge.englishInfinitive}" – <span class="pronoun" id="${currentChallenge.pronoun}">${currentChallenge.pronoun}</span> → <span class="t1000-hint">(Type conjugation backwards)</span>`;
+    promptHTML = `🪞 MIRROR: ${tenseBadge} "${currentChallenge.englishInfinitive}" – <span class="pronoun" id="${currentChallenge.pronoun}">${currentChallenge.pronoun}</span>`;
   }
 
   if (qPrompt) {
     qPrompt.innerHTML = promptHTML;
-    
-    // Add click listeners for info badges
     const promptBadge = qPrompt.querySelector('.tense-badge');
     const promptIcon = qPrompt.querySelector('.context-info-icon');
     if (promptBadge && promptBadge.dataset.infoKey) {
@@ -1034,9 +1047,11 @@ function displayNextT1000Verb() {
 
   if (ansES) {
     ansES.value = '';
+    ansES.placeholder = 'Type the conjugation backwards...';
     ansES.focus();
   }
 }
+
 
 	function validateT1000Answer(userInput, currentChallenge) {
   const cleanInput = userInput.trim().toLowerCase();
@@ -1284,7 +1299,7 @@ function displayNextBossVerb() {
     return;
   }
 
-  // Manejo especial para T-1000 Mirror Boss
+  // Special handling for T-1000 Mirror Boss
   if (game.boss.id === 'mirrorT1000') {
     displayNextT1000Verb();
     return;
@@ -1299,29 +1314,33 @@ function displayNextBossVerb() {
   const tenseEl = document.getElementById('tense-label');
   let promptHTML = '';
 
+  // Añadir tooltips específicos para cada boss
   if (game.boss.id === 'verbRepairer') {
-    if (tenseEl) tenseEl.textContent = 'Repair the corrupted verb';
+    if (tenseEl) {
+      tenseEl.innerHTML = `<span class="boss-title-with-tooltip" data-info-key="verbRepairerBossInfo">Digital Corrupted (${game.boss.verbsCompleted + 1}/${game.boss.totalVerbsNeeded}) <span class="context-info-icon" data-info-key="verbRepairerBossInfo"></span></span>`;
+    }
     const tKey = currentChallenge.tense;
     const tenseObj = tenses.find(t => t.value === tKey) || {};
     const tenseLabel = tenseObj.name || tKey;
     const infoKey = tenseObj.infoKey || '';
     const tenseBadge = `<span class="tense-badge ${tKey}" data-info-key="${infoKey}">${tenseLabel}<span class="context-info-icon" data-info-key="${infoKey}"></span></span>`;
     promptHTML = `${tenseBadge} <span class="boss-challenge">${currentChallenge.glitchedForm}</span>`;
-    
+
   } else if (game.boss.id === 'skynetGlitch') {
-    if (tenseEl) tenseEl.textContent = `Skynet Decode & Conjugate (${game.boss.verbsCompleted + 1}/${game.boss.totalVerbsNeeded})`;
-    
+    if (tenseEl) {
+      tenseEl.innerHTML = `<span class="boss-title-with-tooltip" data-info-key="skynetGlitchBossInfo">Skynet Glitch (${game.boss.verbsCompleted + 1}/${game.boss.totalVerbsNeeded}) <span class="context-info-icon" data-info-key="skynetGlitchBossInfo"></span></span>`;
+    }
     const tKey = currentChallenge.tense;
     const tenseObj = tenses.find(t => t.value === tKey) || {};
     const tenseLabel = tenseObj.name || tKey;
     const infoKey = tenseObj.infoKey || '';
     const tenseBadge = `<span class="tense-badge ${tKey}" data-info-key="${infoKey}">${tenseLabel}<span class="context-info-icon" data-info-key="${infoKey}"></span></span>`;
-    
-    // Mostrar infinitivo glitcheado y pronombre glitcheado
     promptHTML = `${tenseBadge}: <span class="boss-challenge">${currentChallenge.glitchedInfinitive}</span> – <span class="boss-challenge-pronoun">${currentChallenge.glitchedPronoun}</span>`;
-    
+
   } else if (game.boss.id === 'nuclearBomb') {
-    if (tenseEl) tenseEl.textContent = `Defuse the bomb! (${game.boss.verbsCompleted + 1}/${game.boss.totalVerbsNeeded})`;
+    if (tenseEl) {
+      tenseEl.innerHTML = `<span class="boss-title-with-tooltip" data-info-key="nuclearBombBossInfo">Nuclear Countdown (${game.boss.verbsCompleted + 1}/${game.boss.totalVerbsNeeded}) <span class="context-info-icon" data-info-key="nuclearBombBossInfo"></span></span>`;
+    }
     const tKey = currentChallenge.tense;
     const tenseObj = tenses.find(t => t.value === tKey) || {};
     const tenseLabel = tenseObj.name || tKey;
@@ -1330,10 +1349,29 @@ function displayNextBossVerb() {
     promptHTML = `${tenseBadge}: "${currentChallenge.infinitive}" – <span class="pronoun" id="${currentChallenge.pronoun}">${currentChallenge.pronoun}</span>`;
   }
 
+  // Añadir event listeners para los tooltips de los títulos
+  if (tenseEl) {
+    const tooltipIcon = tenseEl.querySelector('.context-info-icon');
+    const titleWithTooltip = tenseEl.querySelector('.boss-title-with-tooltip');
+    if (tooltipIcon) {
+      tooltipIcon.addEventListener('click', e => {
+        e.stopPropagation();
+        if (typeof soundClick !== 'undefined') safePlay(soundClick);
+        const infoKey = tooltipIcon.dataset.infoKey;
+        if (infoKey) openSpecificModal(infoKey);
+      });
+    }
+    if (titleWithTooltip) {
+      titleWithTooltip.addEventListener('click', () => {
+        if (typeof soundClick !== 'undefined') safePlay(soundClick);
+        const infoKey = titleWithTooltip.dataset.infoKey;
+        if (infoKey) openSpecificModal(infoKey);
+      });
+    }
+  }
+
   if (qPrompt) {
     qPrompt.innerHTML = promptHTML;
-
-    // Añadir event listeners para los badges informativos
     const promptBadge = qPrompt.querySelector('.tense-badge');
     const promptIcon = qPrompt.querySelector('.context-info-icon');
     if (promptBadge && promptBadge.dataset.infoKey) {
@@ -1356,6 +1394,7 @@ function displayNextBossVerb() {
     ansES.focus();
   }
 }
+
 
 function endBossBattle(playerWon, message = "") {
   if (ansES) ansES.disabled = false;
@@ -1592,7 +1631,52 @@ function displayClue() {
     feedback.innerHTML = '';
 
     if (game.gameState === 'BOSS_BATTLE') {
-      if (game.boss && game.boss.id === 'skynetGlitch') {
+      if (game.boss && game.boss.id === 'mirrorT1000') {
+        // NUEVO SISTEMA DE PISTAS PARA T-1000
+        if (freeClues > 0) {
+          freeClues--;
+        } else {
+          if (selectedGameMode === 'timer') {
+            const penalty = calculateTimePenalty(currentLevel);
+            timerTimeLeft = Math.max(0, timerTimeLeft - penalty);
+            checkTickingSound();
+            showTimeChange(-penalty);
+          } else if (selectedGameMode === 'lives') {
+            const penalty = 1 + currentLevel;
+            remainingLives -= penalty;
+            updateGameTitle();
+          }
+          streak = 0;
+        }
+
+        const currentChallenge = game.boss.challengeVerbs[game.boss.verbsCompleted];
+        if (!currentChallenge) return;
+
+        // Determinar qué pista mostrar
+        if (!game.boss.hintLevel) game.boss.hintLevel = 0;
+
+        if (game.boss.hintLevel === 0) {
+          // Primera pista: mostrar la conjugación normal
+          feedback.innerHTML = `💡 <em>Clue 1:</em> The normal conjugation is: <strong>${currentChallenge.correctAnswer}</strong>`;
+          game.boss.hintLevel = 1;
+        } else if (game.boss.hintLevel === 1) {
+          // Segunda pista: mostrar la conjugación normal → al revés
+          feedback.innerHTML = `💡 <em>Final Clue:</em> <strong>${currentChallenge.correctAnswer}</strong> → <strong>${currentChallenge.reversedAnswer}</strong>`;
+          game.boss.hintLevel = 2;
+        } else {
+          // Ya se usaron todas las pistas
+          feedback.innerHTML = `💡 No more clues available.`;
+        }
+
+        playFromStart(soundElectricShock);
+        updateClueButtonUI();
+
+        if (ansES) {
+          ansES.value = '';
+          setTimeout(() => ansES.focus(), 0);
+        }
+        return;
+      } else if (game.boss && game.boss.id === 'skynetGlitch') {
         if (selectedGameMode !== 'timer' && selectedGameMode !== 'lives') {
           timerTimeLeft = Math.max(0, timerTimeLeft - 3);
           checkTickingSound();

--- a/tooltips.js
+++ b/tooltips.js
@@ -661,3 +661,72 @@ const specificInfoData = {
            <p>The clues show conjugations in the traditional order, but only for the pronouns you selected for this game.</p>`
   },
 };
+
+const bossTooltips = {
+  verbRepairerBossInfo: {
+    title: "Digital Corrupted Boss",
+    html: `<p><strong>🔧 How to defeat this boss:</strong></p>
+           <p>The digital interference has <strong>corrupted conjugated verbs</strong> by replacing random letters with underscores (_).</p>
+           <p><strong>Your mission:</strong> Look at the corrupted form and type the <strong>complete, correct conjugation</strong>.</p>
+           <p><strong>Example:</strong> If you see "hab_amos" → type "hablamos"</p>
+           <p><strong>Strategy:</strong> Use your knowledge of conjugation patterns and context clues from the tense and meaning to fill in the missing letters.</p>
+           <p><strong>Boss defeats:</strong> 3 correct repairs</p>`
+  },
+  
+  skynetGlitchBossInfo: {
+    title: "Skynet Glitch Boss", 
+    html: `<p><strong>🤖 How to defeat this boss:</strong></p>
+           <p>Skynet has corrupted both the <strong>infinitive and pronoun</strong> by removing random letters (shown as _).</p>
+           <p><strong>Your mission:</strong> Decode both the infinitive and pronoun, then conjugate correctly.</p>
+           <p><strong>Example:</strong> "com_r – _ú" → decode as "comer – tú" → type "comes"</p>
+           <p><strong>Strategy:</strong> 
+           <ul>
+             <li>First, figure out the complete infinitive (com_r = comer)</li>
+             <li>Then, identify the pronoun (_ú = tú)</li>
+             <li>Finally, conjugate using the given tense</li>
+           </ul></p>
+           <p><strong>Boss defeats:</strong> 2 verbs (Normal mode) or 3 verbs (Hard mode)</p>`
+  },
+  
+  nuclearBombBossInfo: {
+    title: "Nuclear Countdown Boss",
+    html: `<p><strong>💣 How to defeat this boss:</strong></p>
+           <p>A nuclear bomb is counting down! You have <strong>30 seconds</strong> to defuse it by correctly conjugating verbs.</p>
+           <p><strong>Your mission:</strong> Conjugate verbs quickly and accurately before time runs out.</p>
+           <p><strong>Time pressure:</strong> Unlike normal gameplay, you have a <strong>hard 30-second limit</strong> for the entire boss battle.</p>
+           <p><strong>Strategy:</strong> 
+           <ul>
+             <li>Work quickly but accurately</li>
+             <li>Use the clue button if you're stuck (costs time/lives but better than exploding!)</li>
+             <li>Focus on verbs you know well to save time</li>
+           </ul></p>
+           <p><strong>Boss defeats:</strong> 4 correct conjugations within 30 seconds</p>
+           <p><strong>⚠️ Warning:</strong> If time runs out, it's instant game over!</p>`
+  },
+  
+  t1000BossInfo: {
+    title: "T-1000 Mirror Boss",
+    html: `<p><strong>🪞 How to defeat this boss:</strong></p>
+           <p>The T-1000 mimics everything in reverse! You must type your conjugations <strong>backwards</strong>.</p>
+           <p><strong>Your mission:</strong> Conjugate the verb normally in your head, then type it <strong>backwards</strong>.</p>
+           <p><strong>Examples:</strong></p>
+           <ul>
+             <li>"hablar – yo" (Present) → think "hablo" → type "olbah"</li>
+             <li>"comer – tú" (Present) → think "comes" → type "semoc"</li>
+           </ul>
+           <p><strong>Strategy:</strong> 
+           <ul>
+             <li>First, work out the normal conjugation</li>
+             <li>Then reverse each letter: first becomes last, etc.</li>
+             <li>Use clues if you're unsure of the normal conjugation</li>
+           </ul></p>
+           <p><strong>Clue system:</strong></p>
+           <ul>
+             <li><em>Clue 1:</em> Shows the normal conjugation</li>
+             <li><em>Final Clue:</em> Shows normal → reversed</li>
+           </ul>
+           <p><strong>Boss defeats:</strong> 1 verb (Easy), 2 verbs (Normal), 3 verbs (Hard)</p>`
+  }
+};
+
+Object.assign(specificInfoData, bossTooltips);


### PR DESCRIPTION
## Summary
- Hide reversed answers in the T-1000 boss challenge and add boss info tooltips
- Add tooltip-enabled prompts for other boss battles
- Implement multi-stage clue system for T-1000 and document boss mechanics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fae9229c8327b2c02eda0e50eb9b