### PR TITLE
Ensure menu fade-out completes reliably

### DIFF
--- a/script.js
+++ b/script.js
@@ -5246,12 +5246,20 @@ function fadeOutToMenu(callback) {
   const screen = document.getElementById('game-screen');
   if (!screen) { callback(); return; }
   screen.classList.add('fade-out');
-  const handler = () => {
+  let done = false;
+  const cleanup = () => {
+    if (done) return;
+    done = true;
+    clearTimeout(fallback);
     screen.classList.remove('fade-out');
-    screen.removeEventListener('animationend', handler);
+    screen.removeEventListener('transitionend', onEnd);
     callback();
   };
-  screen.addEventListener('animationend', handler);
+  const onEnd = e => {
+    if (e.target === screen) cleanup();
+  };
+  screen.addEventListener('transitionend', onEnd);
+  const fallback = setTimeout(cleanup, 700);
 }
     remainingLives = 5;
 


### PR DESCRIPTION
## Summary
- Fix `fadeOutToMenu` to listen for `transitionend` and add a fallback timer so the callback always fires

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*
- Manual Node simulation to verify `quitToSettings` is called and screens toggle

------
https://chatgpt.com/codex/tasks/task_e_68b40b2df4208327aaafd7fc484f5d87