### PR TITLE
Ensure nuclear boss timer fills Chuache box

### DIFF
--- a/style.css
+++ b/style.css
@@ -4163,7 +4163,9 @@ transform: translateY(var(--fire-rise-height, -5em)) scale(0);
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  width: 100%;
   height: 100%;
+  box-sizing: border-box;
   background: linear-gradient(45deg, #ff0000, #ff4444);
   border-radius: 15px;
   padding: 20px;
@@ -4316,7 +4318,8 @@ transform: translateY(var(--fire-rise-height, -5em)) scale(0);
 
 /* Hide Chuache when in nuclear mode */
 #chuache-box.nuclear-mode #chuache-image,
-#chuache-box.nuclear-mode #speech-bubble {
+#chuache-box.nuclear-mode #speech-bubble,
+#chuache-box.nuclear-mode #character-container {
   display: none;
 }
 /* T-1000 Mirror Boss Styles */


### PR DESCRIPTION
## Summary
- Let nuclear countdown stretch to full size with width and border-box layout
- Hide character container in nuclear mode so the timer uses all space

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b58864897c8327bfb2b439294bc21e