### PR TITLE
Fix boss image reference for boss battle

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -529,7 +529,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Elements for Boss Battle transitions
   const gameContainer = document.getElementById('game-container');
   const chuacheImage = document.getElementById('chuache-image');
-  const bossImage = document.getElementById('boss-image');
+  // Use a mutable reference because startBossBattle may replace the element
+  let bossImage = document.getElementById('boss-image');
   const progressContainer = document.getElementById('level-text');
 
   const game = {


### PR DESCRIPTION
## Summary
- Allow replacement of boss image element in startBossBattle by changing constant to a mutable variable

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b59a3123248327b8c1db1612673e75