### PR TITLE
feat: use Rubik Glitch for T-1000

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <link rel="preload" href="../assets/fonts/Schwarzenegger.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="../assets/fonts/PixelSerif_16px_v02.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Rubik+Glitch&display=swap" rel="stylesheet">
   <link rel="preload" href="../verbos.json" as="fetch" crossorigin="anonymous">
    <style>
     body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }

--- a/src/style.css
+++ b/src/style.css
@@ -4337,6 +4337,7 @@ transform: translateY(var(--fire-rise-height, -5em)) scale(0);
   text-align: center;
   color: #2c2c2c;
   box-shadow: inset 0 2px 4px rgba(255,255,255,0.3), 0 4px 8px rgba(0,0,0,0.2);
+  font-family: 'Rubik Glitch', var(--font-pixel);
 }
 
 .t1000-title {
@@ -4388,7 +4389,7 @@ transform: translateY(var(--fire-rise-height, -5em)) scale(0);
   color: #1a1a1a;
   text-shadow: 0 0 2px rgba(255,255,255,0.3);
   font-weight: bold;
-  font-family: 'Courier New', monospace;
+  font-family: 'Rubik Glitch', 'Courier New', monospace;
 
   /* Mirror effect: horizontally flip text */
   transform: scaleX(-1);
@@ -4399,6 +4400,7 @@ transform: translateY(var(--fire-rise-height, -5em)) scale(0);
 #game-screen.t1000-active #answer-input-es::placeholder {
   color: #606060;
   font-style: italic;
+  font-family: 'Rubik Glitch', 'Courier New', monospace;
   /* Placeholder text should also be mirrored for consistency */
   transform: scaleX(-1);
 }
@@ -4414,6 +4416,7 @@ transform: translateY(var(--fire-rise-height, -5em)) scale(0);
   background: linear-gradient(145deg, #c8c8c8, #e0e0e0);
   border: 2px solid #909090;
   color: #2c2c2c;
+  font-family: 'Rubik Glitch', var(--font-pixel);
 }
 
 #game-screen.t1000-active .tense-badge {


### PR DESCRIPTION
## Summary
- load Google "Rubik Glitch" font in index.html
- style T-1000 input, question prompt, and explanation with the new font

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5abc08df483278d278ee9e3aabf76