### PR TITLE
Hide scanline after first phase

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -549,7 +549,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     currentVerbIndex: 0,
     isGameOver: false,
     boss: null, // Will hold the current boss battle state
-
+    scanlineRemoved: false,
     lastBossUsed: null // Track the previously selected boss
   };
 
@@ -1537,6 +1537,12 @@ function endBossBattle(playerWon, message = "") {
     game.verbsInPhaseCount = 0;
     game.gameState = 'PLAYING';
     game.boss = null;
+
+    if (!game.scanlineRemoved && bossesEncounteredTotal === 1) {
+      const gs = document.getElementById('game-screen');
+      if (gs) gs.classList.add('no-scanline');
+      game.scanlineRemoved = true;
+    }
 
     if (progressContainer) updateProgressUI();
 
@@ -5225,6 +5231,7 @@ function quitToSettings() {
   currentBossNumber = 0;
   correctAnswersTotal = 0;
   currentLevel = 0;
+  game.scanlineRemoved = false;
   
   // Ocultar elementos específicos del juego
   const timerContainer = document.getElementById('timer-container');
@@ -5232,7 +5239,7 @@ function quitToSettings() {
   const configFlowScreen = document.getElementById('config-flow-screen');
   
   if (timerContainer) timerContainer.style.display = 'none';
-  if (gameScreen) gameScreen.classList.remove('study-mode-active', 't1000-active');
+  if (gameScreen) gameScreen.classList.remove('study-mode-active', 't1000-active', 'no-scanline');
   
   // Detener animaciones de burbujas
   stopBubbles();

--- a/src/style.css
+++ b/src/style.css
@@ -1604,6 +1604,10 @@ button:active {
   animation: scan-screen 6s linear infinite !important;
   position: fixed;
 }
+.no-scanline::before {
+  content: none;
+  animation: none;
+}
 @keyframes scan-screen {
   0%   { transform: translateY(-100%); }
   100% { transform: translateY(100%); }


### PR DESCRIPTION
## Summary
- disable scanline overlay after the first boss phase
- restore scanline when returning to menu

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ac005714832792c6a2ffdc77640b