### PR TITLE
Preload critical images and add sprite preloading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <link rel="preload" href="../assets/fonts/Schwarzenegger.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="../assets/fonts/PixelSerif_16px_v02.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../assets/images/conjucityhk.webp" as="image">
+  <link rel="preload" href="../assets/images/conjuchuache.webp" as="image">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Rubik+Glitch&display=swap" rel="stylesheet">
@@ -82,8 +84,8 @@
   </div>
 
   <header class="main-header">
-          <img loading="lazy" src="../assets/images/conjucityhk.webp" class="header-city" alt="city"/>
-          <img loading="lazy" src="../assets/images/conjuchuache.webp" class="header-char" alt="char"/>
+          <img src="../assets/images/conjucityhk.webp" class="header-city" alt="city"/>
+          <img src="../assets/images/conjuchuache.webp" class="header-char" alt="char"/>
           <h1 class="glitch-title">
                 <span class="big-letter">T</span>HE
                 <span class="big-letter">C</span>ONJUGATOR

--- a/src/script.js
+++ b/src/script.js
@@ -25,6 +25,22 @@ const nuclearExplosion = new Audio('../assets/sounds/nuclearExplosion.mp3');
 const bombDefused = new Audio('../assets/sounds/bombDefused.mp3');
 const bossT1000Mirror = new Audio('../assets/sounds/bossT1000Mirror.mp3');
 const mirrorShattered = new Audio('../assets/sounds/mirrorShattered.mp3');
+
+// Preload frequently used images to avoid delays during config screens
+function preloadImages() {
+  const sources = [
+    '../assets/images/conjucityhk.webp',
+    '../assets/images/conjuchuache.webp',
+    '../assets/images/musicon.webp',
+    '../assets/images/musicoff.webp',
+    '../assets/images/pixel_bubble.webp',
+    '../assets/images/iconquestion.webp'
+  ];
+  sources.forEach(src => {
+    const img = new Image();
+    img.src = src;
+  });
+}
 menuMusic.loop = true;
 gameMusic.loop = true;
 
@@ -516,6 +532,7 @@ function updateStreakFire(currentStreak) {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
+  preloadImages();
   let selectedGameMode = null;
   let allVerbData = [];
   let currentQuestion = {};


### PR DESCRIPTION
## Summary
- Preload critical header images and remove lazy loading for faster initial render
- Add `preloadImages` helper in `script.js` to warm caches for common sprites

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b520f14483279a51c7bd40692cf7