### PR TITLE
Preload audio for smoother gameplay

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -25,8 +25,56 @@ const nuclearExplosion = new Audio('../assets/sounds/nuclearExplosion.mp3');
 const bombDefused = new Audio('../assets/sounds/bombDefused.mp3');
 const bossT1000Mirror = new Audio('../assets/sounds/bossT1000Mirror.mp3');
 const mirrorShattered = new Audio('../assets/sounds/mirrorShattered.mp3');
+
+// Collect all audio instances in a single array for bulk operations
+const audioElements = [
+  soundCorrect,
+  soundWrong,
+  soundWrongStudy,
+  soundClick,
+  soundStart,
+  soundSkip,
+  menuMusic,
+  gameMusic,
+  soundGameOver,
+  soundbubblepop,
+  soundLifeGained,
+  soundElectricShock,
+  soundTicking,
+  chuacheSound,
+  soundLevelUp,
+  bossDigitalCorrupted,
+  systemRepaired,
+  bossSkynetGlitch,
+  bossNuclearCountdown,
+  nuclearExplosion,
+  bombDefused,
+  bossT1000Mirror,
+  mirrorShattered
+];
+
+// Separate list excluding music tracks for SFX-specific operations
+const sfxAudio = audioElements.filter(a => a !== menuMusic && a !== gameMusic);
+
 menuMusic.loop = true;
 gameMusic.loop = true;
+
+// Preload all audio to reduce playback latency
+function preloadAudio() {
+  let loaded = 0;
+  audioElements.forEach(audio => {
+    audio.preload = 'auto';
+    audio.addEventListener(
+      'canplaythrough',
+      () => {
+        loaded++;
+        // Optional: track progress with loaded / audioElements.length
+      },
+      { once: true }
+    );
+    audio.load();
+  });
+}
 
 // ---- Recorder compatibility check ----
 // Global flag used to disable recorder functionality when unsupported
@@ -194,21 +242,16 @@ function loadSettings() {
     if (typeof targetVolume !== 'undefined') targetVolume = 0.2;
   }
 
+  const sfxElements = sfxAudio;
   if (sfxVol !== null) {
     const vol = parseFloat(sfxVol);
-    [soundCorrect, soundWrong, soundWrongStudy, soundClick, soundStart, soundSkip,
-     soundGameOver, soundbubblepop, soundLifeGained, soundElectricShock, soundTicking,
-     chuacheSound, soundLevelUp, bossDigitalCorrupted, systemRepaired, bossSkynetGlitch,
-     bossNuclearCountdown, nuclearExplosion, bombDefused, bossT1000Mirror, mirrorShattered].forEach(a => { a.volume = vol; });
+    sfxElements.forEach(a => { a.volume = vol; });
     const sfxSlider = document.getElementById('sfx-volume-slider');
     if (sfxSlider) sfxSlider.value = vol;
   } else {
     const sfxSlider = document.getElementById('sfx-volume-slider');
     if (sfxSlider) sfxSlider.value = 1.0;
-    [soundCorrect, soundWrong, soundWrongStudy, soundClick, soundStart, soundSkip,
-     soundGameOver, soundbubblepop, soundLifeGained, soundElectricShock, soundTicking,
-     chuacheSound, soundLevelUp, bossDigitalCorrupted, systemRepaired, bossSkynetGlitch,
-     bossNuclearCountdown, nuclearExplosion, bombDefused, bossT1000Mirror, mirrorShattered].forEach(a => { a.volume = 1.0; });
+    sfxElements.forEach(a => { a.volume = 1.0; });
   }
 
   const animChk = document.getElementById('toggle-animations-setting');
@@ -527,6 +570,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   let remainingLives = 5;
   let targetVolume=0.2;
   loadSettings();
+  preloadAudio();
   let timerTimeLeft = 0;
   let tickingSoundPlaying = false;
   let freeClues = 0;
@@ -2232,9 +2276,7 @@ function displayClue() {
     });
   }
 
-  const allSfx = [soundCorrect, soundWrong, soundWrongStudy, soundClick, soundStart,
-                   soundSkip, soundGameOver, soundbubblepop, soundLifeGained,
-                   soundElectricShock, soundTicking, chuacheSound, soundLevelUp];
+  const allSfx = sfxAudio;
 
   if (sfxVolumeSlider) {
     sfxVolumeSlider.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- Collect all game audio instances into a single array and derive an SFX-only list
- Add `preloadAudio()` to prime audio elements and reduce playback latency
- Invoke audio preloading when the main menu loads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b52108348327b4feac504b73608e