### PR TITLE
Reset T-1000 boss hint level when starting new challenge

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1115,6 +1115,8 @@ function displayNextT1000Verb() {
     return;
   }
 
+  game.boss.hintLevel = 0;
+
   const tenseEl = document.getElementById('tense-label');
   if (tenseEl) {
     // Add tooltip to boss title


### PR DESCRIPTION
## Summary
- Reset hint level at start of each T-1000 challenge so hints begin fresh.

## Testing
- `npm test` (fails: could not find package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b6c102ea8c8327a877179039fa69ad