### PR TITLE
Enable hints for T-1000 boss battle

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -4249,7 +4249,7 @@ function startBossBattle() {
   if (checkAnswerButton) checkAnswerButton.disabled = false;
   if (skipButton) skipButton.disabled = true;
   if (clueButton) {
-    if (selectedBossKey === 'skynetGlitch' || selectedBossKey === 'nuclearBomb') {
+    if (selectedBossKey === 'skynetGlitch' || selectedBossKey === 'nuclearBomb' || selectedBossKey === 'mirrorT1000') {
       clueButton.disabled = false;
       updateClueButtonUI();
     } else {


### PR DESCRIPTION
## Summary
- Allow hint requests when fighting the Mirror T-1000 boss
- Refresh clue button UI after enabling it for eligible bosses

## Testing
- `node --check src/script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c1d291088327ac881089b1e74a95