### PR TITLE
Prevent Chuache reaction before boss battles

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -4163,6 +4163,18 @@ function configureBossVideo(bossImage, videoSrc) {
 }
 
 function startBossBattle() {
+  // Ensure no residual Chuache reaction when a boss appears
+  if (typeof chuacheSound !== 'undefined') {
+    chuacheSound.pause();
+    chuacheSound.currentTime = 0;
+  }
+  const bubble = document.getElementById('speech-bubble');
+  if (bubble) {
+    bubble.classList.add('hidden');
+    bubble.classList.remove('error');
+  }
+  const image = document.getElementById('chuache-image');
+  if (image) image.src = '../assets/images/conjuchuache.webp';
   if (selectedGameMode === 'study') return;
   bossesEncounteredTotal++;
   currentBossNumber++;
@@ -4692,6 +4704,10 @@ correct = possibleCorrectAnswers.includes(ans);
     feedback.innerHTML = ''; // Clear feedback area ONLY on correct answer.
     // *** MODIFICATION END ***
 
+    // Determine if answering this question will trigger a boss battle next
+    const willStartBoss =
+      selectedGameMode !== 'study' && game.verbsInPhaseCount + 1 === 3;
+
     const responseTime = (Date.now() - questionStartTime) / 1000;
     totalResponseTime += responseTime;
     if (responseTime < fastestAnswer) fastestAnswer = responseTime;
@@ -4702,7 +4718,10 @@ correct = possibleCorrectAnswers.includes(ans);
       soundCorrect.currentTime = 0;
       soundCorrect.play().catch(()=>{/* ignora errores por autoplay */});
     }
-    chuacheSpeaks('correct');
+    // Avoid Chuache reactions on the last pre-boss question
+    if (!willStartBoss) {
+      chuacheSpeaks('correct');
+    }
 
     if (selectedGameMode === 'timer' || selectedGameMode === 'lives') {
       correctAnswersTotal++;


### PR DESCRIPTION
## Summary
- Skip Chuache speech on the last question before a boss battle.
- Reset Chuache sound, speech bubble, and image when starting a boss fight.

## Testing
- `npm test` *(fails: Could not read package.json)*
- Node simulation showing `chuacheSpeaks` is skipped when a boss battle is imminent.
- Node simulation verifying `startBossBattle` cleanup pauses sound, hides bubble, and resets image.


------
https://chatgpt.com/codex/tasks/task_e_68b6d1559f6c832787e32bd3636b0146