### PR TITLE
Ensure answer inputs regain focus after submission

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -4149,6 +4149,11 @@ function prepareNextQuestion() {
   const tenseBadge =
     `<span class="tense-badge ${tKey}" data-info-key="${tenseObj.infoKey}">${tenseLabel}<span class="context-info-icon" data-info-key="${tenseObj.infoKey}"></span></span>`;
 
+  const checkAnswerButton = document.getElementById('check-answer-button');
+  if (ansES) ansES.disabled = false;
+  if (ansEN) ansEN.disabled = false;
+  if (checkAnswerButton) checkAnswerButton.disabled = false;
+
   let promptText;
   if (currentOptions.mode === 'productive') {
     promptText = `${tenseBadge}: "${v.infinitive_en}" – ` +
@@ -4189,10 +4194,6 @@ function prepareNextQuestion() {
     });
   }
 
-  const checkAnswerButton = document.getElementById('check-answer-button');
-  if (ansES) ansES.disabled = false;
-  if (ansEN) ansEN.disabled = false;
-  if (checkAnswerButton) checkAnswerButton.disabled = false;
   isCheckingAnswer = false;
 }
 
@@ -5772,6 +5773,9 @@ if (irregularitiesContainer) {
           if (ansEN) ansEN.disabled = true;
           if (checkAnswerButton) checkAnswerButton.disabled = true;
           checkAnswer();
+          if (ansES) ansES.disabled = false;
+          if (ansEN) ansEN.disabled = false;
+          if (checkAnswerButton) checkAnswerButton.disabled = false;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Re-enable answer fields and submission button after checking answers
- Restore input focus when loading the next question

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d9e9e77883279ef2c0d0ffa27790