### PR TITLE
Disable clue button after final hint

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1533,6 +1533,7 @@ function displayUnifiedClue() {
   if (currentOptions.mode === 'receptive') {
     const verbData = currentQuestion.verb;
     feedback.innerHTML = `💡 The English infinitive is <strong>${verbData.infinitive_en}</strong>.`;
+    currentQuestion.hintLevel = 1;
     ansEN.value = '';
     setTimeout(() => ansEN.focus(), 0);
   } else if (currentOptions.mode === 'productive_easy') {
@@ -1587,6 +1588,13 @@ function displayUnifiedClue() {
     }
     ansES.value = '';
     setTimeout(() => ansES.focus(), 0);
+  }
+
+  const clueButton = document.getElementById('clue-button');
+  const maxHintLevel = currentOptions.mode === 'productive' ? 2 : 1;
+  if (clueButton && currentQuestion.hintLevel >= maxHintLevel) {
+    clueButton.disabled = true;
+    clueButton.textContent = 'No more hints';
   }
 }
 
@@ -1724,6 +1732,15 @@ function displayClue() {
       checkTickingSound();
       playFromStart(soundElectricShock);
       displayClue();
+      if (clueButton) {
+        const maxHint = currentOptions.mode === 'productive' ? 2 : 1;
+        if (currentQuestion.hintLevel >= maxHint) {
+          clueButton.disabled = true;
+          clueButton.textContent = 'No more hints';
+        } else {
+          updateClueButtonUI(clueButton, selectedGameMode);
+        }
+      }
       return;
     }
 
@@ -1744,7 +1761,15 @@ function displayClue() {
       streak = 0;
       displayClue();
     }
-    updateClueButtonUI(clueButton, selectedGameMode);
+    if (clueButton) {
+      const maxHint = currentOptions.mode === 'productive' ? 2 : 1;
+      if (currentQuestion.hintLevel >= maxHint) {
+        clueButton.disabled = true;
+        clueButton.textContent = 'No more hints';
+      } else {
+        updateClueButtonUI(clueButton, selectedGameMode);
+      }
+    }
   }
 
   let totalPlayedSeconds = 0;
@@ -3765,6 +3790,7 @@ function prepareNextQuestion() {
   totalQuestions++;
   ansES.value = '';
   ansEN.value = '';
+  if (clueButton) clueButton.disabled = false;
   updateClueButtonUI(clueButton, selectedGameMode);
     isPrizeVerbActive = false; // Reset por defecto
         qPrompt.classList.remove('prize-verb-active'); // Quitar estilo especial

--- a/src/style.css
+++ b/src/style.css
@@ -3275,6 +3275,12 @@ body.is-loading .modal-backdrop:not(.specific-modal-backdrop) { /* :not para no 
     opacity: 0.7;
 }
 
+#clue-button:disabled {
+    background-color: #555;
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+
 
 /* Splash Step */
 #splash-step {


### PR DESCRIPTION
## Summary
- Track hint level in receptive mode and disable clue button when all hints are used
- Re-enable clue button for each new question
- Add disabled style for clue button to show greyed state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b81cd5c04083279525efb351677f8c