### PR TITLE
Add tooltip for color-coded clues

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1555,8 +1555,15 @@ function displayUnifiedClue() {
       .map(pr => `<span class="hint-btn ${pr}">${conj[pr]}</span>`)
       .join('');
 
-    const tooltipText = "Color order: yo(yellow), tú(orange), vos(dark orange), él/ella(pink), nosotros(purple), vosotros(blue), ellos/ellas(white)";
-    feedback.innerHTML = `❌ <em>Clue:</em> <span title="${tooltipText}">ℹ️</span> ` + conjugationsToShow;
+    feedback.innerHTML = `❌ <em>Clue:</em> <span class="context-info-icon" data-info-key="clueColorsInfo"></span> ` + conjugationsToShow;
+    const clueIcon = feedback.querySelector('.context-info-icon');
+    if (clueIcon) {
+      clueIcon.addEventListener('click', e => {
+        e.stopPropagation();
+        if (typeof soundClick !== 'undefined') safePlay(soundClick);
+        openSpecificModal(clueIcon.dataset.infoKey);
+      });
+    }
     playFromStart(soundElectricShock);
     currentQuestion.hintLevel = 1;
 
@@ -1583,6 +1590,14 @@ function displayUnifiedClue() {
         .join('');
 
       feedback.innerHTML = `❌ <em>Clue 2:</em> <span class="context-info-icon" data-info-key="clueColorsInfo"></span> ` + conjugationsToShow;
+      const clueIcon = feedback.querySelector('.context-info-icon');
+      if (clueIcon) {
+        clueIcon.addEventListener('click', e => {
+          e.stopPropagation();
+          if (typeof soundClick !== 'undefined') safePlay(soundClick);
+          openSpecificModal(clueIcon.dataset.infoKey);
+        });
+      }
       playFromStart(soundElectricShock);
       currentQuestion.hintLevel = 2;
     }


### PR DESCRIPTION
## Summary
- Replace inline ℹ️ icon in clue feedback with context tooltip for pronoun colors
- Hook up interactive handler to open the Clue Color Guide modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b824ec5a908327ab5faf3d4e0e7cc0