### PR TITLE
Fix irregularity type filtering

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -3516,7 +3516,7 @@ async function loadVerbs() {
 
   } else {
 
-    if (selectedselectedTypes.length === 0) {
+    if (selectedTypes.length === 0) {
       alert('Please select at least one type of irregularity if you do not choose specific verbs..');
       allVerbData = [];
       return false;
@@ -3525,7 +3525,7 @@ async function loadVerbs() {
     verbsToConsiderForGame = initialRawVerbData.filter(v =>
       currentOptions.tenses.some(tenseKey => // Para cada tiempo seleccionado...
         (v.types[tenseKey] || []).some(typeInVerb => // ...el verbo debe tener un tipo de irregularidad...
-          selectedIrregularityTypes.includes(typeInVerb) // ...que esté en los tipos de irregularidad seleccionados por el usuario.
+          selectedTypes.includes(typeInVerb) // ...que esté en los tipos de irregularidad seleccionados por el usuario.
         )
       )
     );


### PR DESCRIPTION
## Summary
- reference the selected verb type list when validating irregularity filters in loadVerbs
- ensure verb filtering checks the proper irregularity selections

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8eabe681c832783ac320153a5ff9c