### PR TITLE
Add option to disable boss battles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -77,6 +77,7 @@
       </fieldset>
       <fieldset>
           <legend>Miscellaneous</legend>
+          <label><input type="checkbox" id="disable-bosses-setting"> Disable Boss Battles</label>
           <button id="reset-settings-button">Reset All Settings</button>
       </fieldset>
 

--- a/src/script.js
+++ b/src/script.js
@@ -2092,6 +2092,14 @@ function displayClue() {
       applyChuacheVisibility();
     });
   }
+  const disableBossesChk = document.getElementById('disable-bosses-setting');
+  if (disableBossesChk) {
+    disableBossesChk.addEventListener('change', () => {
+      settings.bossesDisabled = disableBossesChk.checked;
+      window.bossesDisabled = settings.bossesDisabled;
+      saveSetting('bossesDisabled', disableBossesChk.checked);
+    });
+  }
   const vosChk = document.getElementById('default-enable-vos-setting');
   if (vosChk) {
     vosChk.addEventListener('change', () => {
@@ -2108,6 +2116,7 @@ function displayClue() {
       localStorage.removeItem('animationsEnabled');
       localStorage.removeItem('chuacheReactionsEnabled');
       localStorage.removeItem('defaultVosEnabled');
+      localStorage.removeItem('bossesDisabled');
       targetVolume = loadSettings();
     });
   }
@@ -4441,7 +4450,9 @@ correct = possibleCorrectAnswers.includes(ans);
 
     // Determine if answering this question will trigger a boss battle next
     const willStartBoss =
-      selectedGameMode !== 'study' && game.verbsInPhaseCount + 1 === 3;
+      selectedGameMode !== 'study' &&
+      !settings.bossesDisabled &&
+      game.verbsInPhaseCount + 1 === 3;
 
     const responseTime = (Date.now() - questionStartTime) / 1000;
     totalResponseTime += responseTime;
@@ -4540,7 +4551,11 @@ else                   timeBonus = 10;
 
     game.verbsInPhaseCount++;
     // TODO: Restore threshold to 9 for production
-    if (game.verbsInPhaseCount === 3 && selectedGameMode !== 'study') {
+    if (
+      game.verbsInPhaseCount === 3 &&
+      selectedGameMode !== 'study' &&
+      !settings.bossesDisabled
+    ) {
       game.gameState = 'BOSS_BATTLE';
       startBossBattle();
       return;

--- a/src/settings.js
+++ b/src/settings.js
@@ -15,13 +15,15 @@ export const settings = {
     const stored = localStorage.getItem('chuacheReactionsEnabled');
     return stored !== null ? stored === 'true' : true;
   })(),
-  defaultVosEnabled: false
+  defaultVosEnabled: false,
+  bossesDisabled: false
 };
 
 if (typeof window !== 'undefined') {
   window.animationsEnabled = settings.animationsEnabled;
   window.chuacheReactionsEnabled = settings.chuacheReactionsEnabled;
   window.defaultVosEnabled = settings.defaultVosEnabled;
+  window.bossesDisabled = settings.bossesDisabled;
 }
 
 // Lista de efectos de sonido, excluyendo las pistas de música.
@@ -52,15 +54,18 @@ export function loadSettings() {
   const anim = localStorage.getItem('animationsEnabled');
   const chuache = localStorage.getItem('chuacheReactionsEnabled');
   const vos = localStorage.getItem('defaultVosEnabled');
+  const bosses = localStorage.getItem('bossesDisabled');
 
   settings.animationsEnabled = anim !== null ? anim === 'true' : false;
   settings.chuacheReactionsEnabled = chuache !== null ? chuache === 'true' : true;
   settings.defaultVosEnabled = vos === 'true';
+  settings.bossesDisabled = bosses === 'true';
 
   if (typeof window !== 'undefined') {
     window.animationsEnabled = settings.animationsEnabled;
     window.chuacheReactionsEnabled = settings.chuacheReactionsEnabled;
     window.defaultVosEnabled = settings.defaultVosEnabled;
+    window.bossesDisabled = settings.bossesDisabled;
   }
 
   if (musicVol !== null) {
@@ -93,6 +98,8 @@ export function loadSettings() {
   if (chuacheChk) chuacheChk.checked = settings.chuacheReactionsEnabled;
   const vosChk = document.getElementById('default-enable-vos-setting');
   if (vosChk) vosChk.checked = settings.defaultVosEnabled;
+  const bossesChk = document.getElementById('disable-bosses-setting');
+  if (bossesChk) bossesChk.checked = settings.bossesDisabled;
 
   applyChuacheVisibility();
 


### PR DESCRIPTION
## Summary
- add a checkbox in the options modal to disable boss battles
- persist the new setting in the settings module and sync the UI state
- respect the setting when toggling boss battle logic and when resetting settings

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c92a62ef608327b3e52e4eb764584a