### PR TITLE
Add simple past regular category

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -2480,6 +2480,8 @@ function updatePronounDropdownCount() {
     { value: 'regular', name: 'Regular', negativeName: 'Irregular',
       times: ['present', 'past_simple', 'present_perfect', 'future_simple', 'condicional_simple', 'imperfect_indicative'],
       hint: '', infoKey: 'regularInfo' },
+    { value: 'regular_past_simple', name: 'Regular (Pretérito)', times: ['past_simple'],
+      hint: '⚙️ hablar → hablé, hablaste, habló', infoKey: 'regularPastSimpleInfo' },
     { value: 'first_person_irregular', name: '1st Person', times: ['present'],
       hint: '⚙️ salir -> salgo', infoKey: 'firstPersonInfo' },
     { value: 'stem_changing', name: 'Stem Change', times: ['present'],
@@ -3669,7 +3671,17 @@ function updateVerbTypeButtonsVisualState() {
         if (verbObj && verbObj.types) {
             currentSelectedTenses.forEach(tense => {
                 const typesForTense = verbObj.types[tense] || [];
-                typesForTense.forEach(type => activeTypesByTense[tense].add(type));
+                const normalizedTypes = new Set(typesForTense);
+
+                if (
+                    tense === 'past_simple' &&
+                    typesForTense.length > 0 &&
+                    typesForTense.every(type => type === 'regular')
+                ) {
+                    normalizedTypes.add('regular_past_simple');
+                }
+
+                normalizedTypes.forEach(type => activeTypesByTense[tense].add(type));
             });
         }
     });
@@ -3761,7 +3773,11 @@ function applyIrregularityAndTenseFiltersToVerbList() {
                 matchesThisTense = verbTypesForTense.some(type => type !== 'regular');
             } else {
                 matchesThisTense = activeTypesForTense.every(requiredType => {
-                    if (requiredType === 'regular') {
+                    const requiresStrictRegular =
+                        requiredType === 'regular' ||
+                        (requiredType === 'regular_past_simple' && tense === 'past_simple');
+
+                    if (requiresStrictRegular) {
                         return verbTypesForTense.includes('regular') &&
                                verbTypesForTense.every(type => type === 'regular');
                     }

--- a/src/tooltips.js
+++ b/src/tooltips.js
@@ -258,6 +258,31 @@ const specificInfoData = {
            </div>
            <p><strong>Examples:</strong> comer, hablar, vivir, estudiar, trabajar</p>`
   },
+  regularPastSimpleInfo: {
+    title: "Regular Pretérito (Simple Past)",
+    html: `<p>These verbs keep a stable stem in the simple past, so you only need to add the standard endings.</p>
+           <div class="conjugation-boxes">
+             <table class="conjugation-box">
+               <caption>Endings for -ar verbs</caption>
+               <tr><td>yo</td><td>-é</td></tr>
+               <tr><td>tú</td><td>-aste</td></tr>
+               <tr><td>él/ella/ud.</td><td>-ó</td></tr>
+               <tr><td>nosotros</td><td>-amos</td></tr>
+               <tr><td>vosotros</td><td>-asteis</td></tr>
+               <tr><td>ellos/ellas/uds.</td><td>-aron</td></tr>
+             </table>
+             <table class="conjugation-box">
+               <caption>Endings for -er / -ir verbs</caption>
+               <tr><td>yo</td><td>-í</td></tr>
+               <tr><td>tú</td><td>-iste</td></tr>
+               <tr><td>él/ella/ud.</td><td>-ió</td></tr>
+               <tr><td>nosotros</td><td>-imos</td></tr>
+               <tr><td>vosotros</td><td>-isteis</td></tr>
+               <tr><td>ellos/ellas/uds.</td><td>-ieron</td></tr>
+             </table>
+           </div>
+           <p class="recall-tip"><strong>Example:</strong> hablar → hablé, hablaste, habló</p>`
+  },
   firstPersonInfo: {
     title: "1st Person Irregular (Present)",
     html: `<p>Only the <em>yo</em> form is irregular. The other forms are regular.</p>


### PR DESCRIPTION
## Summary
- add a dedicated "Regular (Pretérito)" irregularity filter entry for the simple past tense
- allow the filter logic to treat the new entry as verbs that stay regular in the preterite while keeping existing regular behaviour
- document the new filter with a tooltip that highlights the standard -ar and -er/-ir endings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9421d40ec8327817a089108b3c70a