### PR TITLE
Reset phase counters when starting games

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -5048,6 +5048,8 @@ function startTimerMode() {
     clearInterval(game.boss.countdownInterval);
     game.boss.countdownInterval = null;
   }
+  game.verbsInPhaseCount = 0;
+  game.gameState = 'PLAYING';
   totalQuestions = 0;
   totalCorrect = 0;
   totalIncorrect = 0;
@@ -5130,6 +5132,8 @@ function startLivesMode() {
     clearInterval(game.boss.countdownInterval);
     game.boss.countdownInterval = null;
   }
+  game.verbsInPhaseCount = 0;
+  game.gameState = 'PLAYING';
   totalQuestions = 0;
   totalCorrect = 0;
   totalIncorrect = 0;
@@ -5651,6 +5655,8 @@ finalStartGameButton.addEventListener('click', async () => {
     } else if (window.selectedGameMode === 'lives') {
         startLivesMode();
     } else {
+        game.verbsInPhaseCount = 0;
+        game.gameState = 'PLAYING';
         levelState.bossesEncounteredTotal = 0;
         levelState.currentBossNumber = 0;
         levelState.freeClues = 0;


### PR DESCRIPTION
## Summary
- reset `game.verbsInPhaseCount` and `game.gameState` when entering timer or lives modes to avoid leftover boss progress
- ensure other game mode launches also clear the phase counter before starting a new run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca6afd133883278b6e5daad035d338