### PR TITLE
Enable per-tense reflexive toggles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -229,7 +229,6 @@
               <span class="context-info-icon" data-info-key="accentHelp"></span>
             </button>
           </div>
-          <button type="button" id="toggle-reflexive" class="toggle-button">Reflexive Verbs <span class="context-info-icon" data-info-key="reflexiveInfo"></span></button>
         </div>
         <div id="verb-irregularities-container">
           <p><strong>☠️Verb Irregularities☠️</strong></p>

--- a/src/style.css
+++ b/src/style.css
@@ -391,11 +391,6 @@ body::after {
 }
 
 
-#toggle-reflexive {
-  position: relative;
-  padding-right: 28px;
-}
-
 #toggle-ignore-accents {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary
- add a reflexive option to every tense-specific irregularity section and remove the global reflexive toggle button
- capture the selected irregularity types per tense when starting a game to keep reflexive bonuses and filtering in sync
- respect per-tense reflexive selections when auto-selecting verbs and showing score feedback icons

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca6f4629848327b853f251fe5e14c3