### PR TITLE
Prevent reflexive verbs without selection

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -3966,10 +3966,20 @@ function applyIrregularityAndTenseFiltersToVerbList() {
             evaluatedAnyTense = true;
 
             const verbTypesForTense = verbObj.types?.[tense] || [];
+            const stateEntryForTense = stateEntriesByTense[tense];
+            const manualDeselections = stateEntryForTense?.manuallyDeselected || new Set();
+            const hasReflexiveType = verbTypesForTense.includes('reflexive');
+            const reflexiveSelected = activeTypesForTense.includes('reflexive');
+            const reflexiveAllowedByFallback = useIrregularFallback && !manualDeselections.has('reflexive');
+
+            if (hasReflexiveType && !reflexiveSelected && !reflexiveAllowedByFallback) {
+                matchesAllTenses = false;
+                break;
+            }
+
             let matchesThisTense = false;
 
             if (useIrregularFallback) {
-                const manualDeselections = stateEntriesByTense[tense]?.manuallyDeselected || new Set();
                 matchesThisTense = verbTypesForTense.some(type => type !== 'regular' && !manualDeselections.has(type));
             } else {
                 matchesThisTense = activeTypesForTense.every(requiredType => {


### PR DESCRIPTION
## Summary
- ensure reflexive verbs fail filtering unless Reflexive is selected for the tense
- reuse manual deselection data so the irregular fallback also respects Reflexive toggles

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca77ea15d08327aca0b43733d268d0