### PR TITLE
Adjust irregularity filter selection logic

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -3981,16 +3981,16 @@ function applyIrregularityAndTenseFiltersToVerbList() {
                 break;
             }
 
-            let matchesThisTense = false;
-
-            matchesThisTense = activeTypesForTense.every(requiredType => {
+            const matchesThisTense = activeTypesForTense.some(requiredType => {
                 const requiresStrictRegular =
                     requiredType === 'regular' ||
                     (requiredType === 'regular_past_simple' && tense === 'past_simple');
 
                 if (requiresStrictRegular) {
-                    return verbTypesForTense.includes('regular') &&
-                           verbTypesForTense.every(type => type === 'regular');
+                    return (
+                        verbTypesForTense.includes('regular') &&
+                        verbTypesForTense.every(type => type === 'regular')
+                    );
                 }
 
                 return verbTypesForTense.includes(requiredType);
@@ -4002,8 +4002,10 @@ function applyIrregularityAndTenseFiltersToVerbList() {
             }
         }
 
-        const shouldSelectVerb = matchesAllTenses && evaluatedAnyTense;
-        verbButton.classList.toggle('selected', shouldSelectVerb);
+        if (evaluatedAnyTense) {
+            const shouldSelectVerb = matchesAllTenses;
+            verbButton.classList.toggle('selected', shouldSelectVerb);
+        }
     });
 
     updateVerbDropdownCount();


### PR DESCRIPTION
## Summary
- treat irregularity filters as inclusive per tense so verbs match any selected irregularity
- avoid overriding manual verb selections when no irregularity filters are active

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce397a5c608327b44ecab4518e2f2d